### PR TITLE
Avoid dependency on nsl in all situations

### DIFF
--- a/cmake/cares.cmake
+++ b/cmake/cares.cmake
@@ -18,10 +18,10 @@ if(gRPC_CARES_PROVIDER STREQUAL "module")
   endif()
   set(CARES_SHARED OFF CACHE BOOL "disable shared library")
   set(CARES_STATIC ON CACHE BOOL "link cares statically")
-  if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
-    # See https://github.com/grpc/grpc/issues/17255
-    set(HAVE_LIBNSL OFF CACHE BOOL "avoid cares dependency on libnsl")
-  endif()
+
+  # See https://github.com/grpc/grpc/issues/17255
+  set(HAVE_LIBNSL OFF CACHE BOOL "avoid cares dependency on libnsl")
+
   add_subdirectory("${CARES_ROOT_DIR}" third_party/cares/cares)
 
   if(TARGET c-ares)


### PR DESCRIPTION
@nicolasnoble

nsl library is not need by ClickHouse
I encounter this problem:
my env has nsl library, and build clickhouse with all default configuration, it will build a clickhouse binary that has a dependency on nsl. When I deploy ClickHouse on other server which do not have nsl library , it is not work. So I think we should definitely avoid depend on nsl library.

```
hewenting@dell123 ~ $ ldconfig -p |grep nsl
	libnsl.so.2 (libc6,x86-64) => /home/amos/gentoo/usr/lib64/libnsl.so.2
	libnsl.so.1 (libc6,x86-64, OS ABI: Linux 3.2.0) => /home/amos/gentoo/lib64/libnsl.so.1
	libnsl.so (libc6,x86-64) => /home/amos/gentoo/usr/lib64/libnsl.so
hewenting@dell123 ~ $
hewenting@dell123 ~/ClickHouse_src/build $ ldd programs/clickhouse
	linux-vdso.so.1 (0x00007ffe543ca000)
	libnsl.so.2 => /home/amos/gentoo/usr/lib64/libnsl.so.2 (0x00007fac5ec29000)
	librt.so.1 => /home/amos/gentoo/lib64/librt.so.1 (0x00007fac5ec1f000)
	libdl.so.2 => /home/amos/gentoo/lib64/libdl.so.2 (0x00007fac5ec1a000)
	libpthread.so.0 => /home/amos/gentoo/lib64/libpthread.so.0 (0x00007fac5ebfa000)
	libc.so.6 => /home/amos/gentoo/lib64/libc.so.6 (0x00007fac5ea3e000)
	libm.so.6 => /home/amos/gentoo/lib64/libm.so.6 (0x00007fac5e8fb000)
	libtirpc.so.3 => /home/amos/gentoo/usr/lib64/libtirpc.so.3 (0x00007fac5e8d0000)
	/home/amos/gentoo/lib64/ld-linux-x86-64.so.2 (0x00007fac5ec60000)
hewenting@dell123 ~/ClickHouse_src/build $
```