### PR TITLE
Prevent c-ares from being built so it can be linked against project-wide c-ares

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,6 @@ endif()
 include(cmake/abseil-cpp.cmake)
 include(cmake/address_sorting.cmake)
 include(cmake/benchmark.cmake)
-include(cmake/cares.cmake)
 include(cmake/gflags.cmake)
 include(cmake/protobuf.cmake)
 include(cmake/re2.cmake)
@@ -15784,7 +15783,6 @@ install(FILES
   DESTINATION ${gRPC_INSTALL_CMAKEDIR}
 )
 install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/Findc-ares.cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/Findre2.cmake
   DESTINATION ${gRPC_INSTALL_CMAKEDIR}/modules
 )


### PR DESCRIPTION
ClickHouse needs to be linked against c-ares in order to perform reverse DNS queries with multiple PTR records. `gRPC` built-in c-ares is conflicting with project wide. Below you can find the approaches considered:

1. Build c-ares as a submodule and link grpc against it. Requires changes in grpc, which is not in the scope of this PR, but it would be necessary.
2. Link clickhouse_common_io against c-ares built by grpc. If c-ares target doesn't exist because grpc wasn't built, build c-ares submodule. Dependecy graph becomes a bit messy and not clear, but leaves grpc untouched.
3. Build c-ares as a submodule, but with different name. I don't see this one as a good option, but leaving it on the table.

Approach #1 was the one recommended by @[tavplubix](https://github.com/tavplubix). Approach #2 will be the fall-back one in case this one doesn't work.

More info on https://github.com/ClickHouse/ClickHouse/pull/37827

@karthikravis
